### PR TITLE
Make sure t_df and q_df have not duplicates before merging

### DIFF
--- a/src/wdqms/wdqms.py
+++ b/src/wdqms/wdqms.py
@@ -468,6 +468,11 @@ class WDQMS:
             q_df = stn_df[stn_df['var_id'] == q_id]
             t_df = stn_df[stn_df['var_id'] == t_id]
 
+            # Make sure there are no duplicates in q_df and t_df before merging 
+            columns_to_compare = ['Station_ID', 'Latitude', 'Longitude', 'Pressure', 'Time']
+            q_df = q_df.drop_duplicates(subset=columns_to_compare)
+            t_df = t_df.drop_duplicates(subset=columns_to_compare)
+
             # Merge dataframes on common keys using an inner join
             merged_df = pd.merge(q_df, t_df, on=['Station_ID', 'Latitude', 'Longitude', 'Pressure', 'Time'], suffixes=('_q', '_t'), how='inner')
 


### PR DESCRIPTION
This PR proposes a solution to fix ValueError in _genqsat function. 
The solution is to make sure there are no duplicates for q_df and t_df before merging.  

ValueError encountered while processing TEMP report for 20240531 12 Z and 20240602 12Z cycles:
Failed at the following stations:
2024053112 - Station_ID 47827
2024060212 - Station_ID 48820 

I am testing the proposed solution from 2024050800 to 2024060218; will report the results soon. 

Resolve [Issue #13](https://github.com/kevindougherty-noaa/wdqms/issues/13)